### PR TITLE
Revert "Bump com.google.protobuf:protobuf-java from 4.26.0 to 4.26.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 
   <properties>
     <!--Dependency versions-->
-    <protobuf.version>4.26.1</protobuf.version>
+    <protobuf.version>4.26.0</protobuf.version>
     <protoc.version>4.26.0</protoc.version>
 
     <!-- Spotbugs -->


### PR DESCRIPTION
Reverts ArpNetworking/prometheus-remote-protocol#16
protobuf 4 is not ready for prime time in java land